### PR TITLE
Leverage existing Meteor supported method for handling regex

### DIFF
--- a/lib/smartquery.js
+++ b/lib/smartquery.js
@@ -17,24 +17,7 @@ SmartQuery.getPublicationName = function (collection) {
 
 if (Meteor.isClient) {
 
-	var resolveSelectorRegExp = function(selector) {
-		_.each(selector, function(condition, key) {
-			if (condition instanceof RegExp) {
-				var regex = { $regex: condition.source, $options: "" };
-				if (condition.ignoreCase) {
-					regex.$options += 'i';
-				}
-				if (condition.multiline) {
-					regex.$options += 'm';
-				}
-				selector[key] = regex;
-				return;
-			}
-			if (_.isObject(condition)) {
-				resolveSelectorRegExp(condition);
-			}
-		});
-	};
+  var _rewriteSelector = Mongo ? Mongo.Collection._rewriteSelector : Meteor.Collection._rewriteSelector;
 
 
   // the main SmartQuery function on the client
@@ -58,7 +41,7 @@ if (Meteor.isClient) {
     if (cursor.sorter !== null)               { options.sort = convertSorter(cursor.sorter); }
 
     // fix regexp
-    resolveSelectorRegExp(selector);
+    selector = _rewriteSelector(selector);
 
     // note: recreating the subscription each time seems inneficient,
     // but since the subscription is called from within a reactive computation


### PR DESCRIPTION
Found that Meteor is already handling the regex issue.

https://github.com/meteor/meteor/blob/15cdbca24888bfdff3ad43c1891a1719c09b3dc5/packages/mongo/collection.js#L341-L378

Might as well leverage their work.
